### PR TITLE
Don't exclude all rules/files by default

### DIFF
--- a/review.py
+++ b/review.py
@@ -6,11 +6,6 @@ import pyres
 import flake
 from settings import settings
 
-# TODO(jmcarp) Revert exclude when stable
-DEFAULT_CONFIG = {
-    'exclude': '*',
-}
-
 q = pyres.ResQ(
     '{0}:{1}'.format(settings['host'], settings['port']),
     settings['password'],
@@ -23,7 +18,6 @@ class PythonReviewJob(object):
     @staticmethod
     def perform(filename, commit_sha, pull_request_number, patch, content, config):
         opts = {}
-        opts.update(DEFAULT_CONFIG)
         opts.update(flake.parse_config(config))
         violations = [
             {'line': error[0], 'message': error[3]}


### PR DESCRIPTION
I _believe_ this was initially included because we wanted to take an
opt-in approach, and at the time of hound-python being developed this
was only achievable at the linter config level. We now have the concept
of beta languages in Hound, which are disabled at the linter level by
default.

Removing this default config means those who opt-in to Python linting
will get the default config of the linter itself, rather than nothing.