### PR TITLE
Use dictionary for job arguments

### DIFF
--- a/review.py
+++ b/review.py
@@ -16,12 +16,19 @@ class PythonReviewJob(object):
     queue = 'python_review'
 
     @staticmethod
-    def perform(filename, commit_sha, pull_request_number, patch, content, config):
-        opts = {}
-        opts.update(flake.parse_config(config))
+    def perform(attributes):
+        commit_sha = attributes["commit_sha"]
+        config = attributes["config"]
+        content = attributes["content"]
+        filename = attributes["filename"]
+        patch = attributes["patch"]
+        pull_request_number = attributes["pull_request_number"]
+
+        linter_config = {}
+        linter_config.update(flake.parse_config(config))
         violations = [
             {'line': error[0], 'message': error[3]}
-            for error in flake.check_code(content, filename, **opts)
+            for error in flake.check_code(content, filename, **linter_config)
         ]
         payload = {
             'class': 'CompletedFileReviewJob',

--- a/test_review.py
+++ b/test_review.py
@@ -18,7 +18,14 @@ class TestReview:
         [flake8]
         exclude=
         '''
-        review.PythonReviewJob.perform('test.py', '3e01a4', 3, 7, 'import this', config)
+        review.PythonReviewJob.perform({
+            'commit_sha': '3e01a4',
+            'config': config,
+            'content': 'import this',
+            'filename': 'test.py',
+            'patch': 7,
+            'pull_request_number': 3,
+        })
         violations = [
             {'line': 1, 'message': "'this' imported but unused"},
             {'line': 1, 'message': 'no newline at end of file'},
@@ -41,7 +48,14 @@ class TestReview:
         ignore=F401
         exclude=
         '''
-        review.PythonReviewJob.perform('test.py', '3e01a4', 3, 7, 'import this', config)
+        review.PythonReviewJob.perform({
+            'commit_sha': '3e01a4',
+            'config': config,
+            'content': 'import this',
+            'filename': 'test.py',
+            'patch': 7,
+            'pull_request_number': 3,
+        })
         violations = [{'line': 1, 'message': 'no newline at end of file'}]
         payload = {
             'class': 'CompletedFileReviewJob',
@@ -61,7 +75,14 @@ class TestReview:
         ignore=F401
         exclude=test*
         '''
-        review.PythonReviewJob.perform('test.py', '3e01a4', 3, 7, 'import this', config)
+        review.PythonReviewJob.perform({
+            'commit_sha': '3e01a4',
+            'config': config,
+            'content': 'import this',
+            'filename': 'test.py',
+            'patch': 7,
+            'pull_request_number': 3,
+        })
         payload = {
             'class': 'CompletedFileReviewJob',
             'args': [{


### PR DESCRIPTION
Hound's API for linting services is to serialize a single dictionary
argument for each job. This change brings the Python service into
conformance.